### PR TITLE
fix/java_version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,8 @@
               <artifactId>maven-compiler-plugin</artifactId>
               <version>2.3.2</version>
               <configuration>
-                  <source>1.7</source>
-                  <target>1.7</target>
+                  <source>1.8</source>
+                  <target>1.8</target>
               </configuration>
            </plugin>
 		   


### PR DESCRIPTION
Fix error 
[ERROR] error: Source option 7 is no longer supported. Use 8 or later. [ERROR] error: Target option 7 is no longer supported. Use 8 or later.